### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 install:
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,20 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
     },
     "autoload": {
-        "psr-4": { "Ahc\\": "src/" }
+        "psr-4": {
+            "Ahc\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ahc\\Test\\": "tests/src/"
+        }
     },
     "extra": {
         "branch-alias": { "dev-master": "1.0-dev" }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+        <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/src/HtmlUpTest.php
+++ b/tests/src/HtmlUpTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Ahc\HtmlUp;
+namespace Ahc\HtmlUp\Test;
 
-class HtmlUpTest extends PHPUnit_Framework_TestCase
+use Ahc\HtmlUp;
+use PHPUnit\Framework\TestCase;
+
+class HtmlUpTest extends TestCase
 {
     /**
      * @dataProvider dataSrc
@@ -94,7 +97,7 @@ class HtmlUpTest extends PHPUnit_Framework_TestCase
             ],
             [
                 'Code with indent',
-                "    <?php phpinfo();",
+                '    <?php phpinfo();',
                 '<pre><code>&lt;?php phpinfo();</code></pre>',
             ],
             [
@@ -153,7 +156,7 @@ class HtmlUpTest extends PHPUnit_Framework_TestCase
             ],
             [
                 'URLs',
-                "[label](https://link) <http://anotherlink> <mail@localhost>",
+                '[label](https://link) <http://anotherlink> <mail@localhost>',
                 '<p><a href="https://link">label</a>' .
                     ' <a href="http://anotherlink">http://anotherlink</a>' .
                     ' <a href="mailto:mail@localhost">mail@localhost</a></p>',


### PR DESCRIPTION
# Changed log
- Set the multiple PHPUnit versions to be compatible with PHP versions.
- Add the `autoload-dev` to load the test of classes automatically.
- Use the class-based PHPUnit namespace to support the stable PHPUnit version.
- Add the `php-7.2` test in Travis CI build.
- Add the white filter list in `phpunit.xml` setting.
- Let this package require `php-5.4+` in the next release version.